### PR TITLE
Fix missing .bashrc of vagrant VM by zeus.py

### DIFF
--- a/zeus.py
+++ b/zeus.py
@@ -44,6 +44,7 @@ cp(source_path + "/Vagrantfile", project_path)
 cp(source_path + "/provision.sh", project_path)
 # Installing requirements.txt
 cp(source_path + "/requirements.txt", project_path)
+cp(source_path + "/.bashrc", project_path)
 
 with colors.orchid:
     print "========== Setting up bare README.md =========="


### PR DESCRIPTION
Fix missing .bashrc of vagrant VM by zeus.py
- There was an error where .bashrc runs inside
  vagrant VM when using vagrant up, but when
  using zeus.py, it does not run this file.
- The reason is that .bashrc was not copied by
  zeus.py
- The solution is to add one line to include
  copying .bashrc to the new project folder
  created by zeus.py and in which vagrant up
  shall run.

Closes #30
