### PR TITLE
Adds powershell script to install dependent packages in windows

### DIFF
--- a/bootstrap/install_packages/Get-InstalledSoftware.ps1
+++ b/bootstrap/install_packages/Get-InstalledSoftware.ps1
@@ -1,0 +1,60 @@
+﻿#Visit below link for usage instructions and other details.
+# http://techibee.com/powershell/powershell-script-to-query-softwares-installed-on-remote-computer/1389
+
+[cmdletbinding()]
+param(
+ [parameter(ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+ [string[]]$ComputerName = $env:computername
+)
+
+begin {
+ $UninstallRegKeys=@("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+					"SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall")
+}
+
+process {
+ foreach($Computer in $ComputerName) {
+  Write-Verbose "Working on $Computer"
+	if(Test-Connection -ComputerName $Computer -Count 1 -ea 0) {
+		foreach($UninstallRegKey in $UninstallRegKeys) {
+			try {
+				$HKLM   = [microsoft.win32.registrykey]::OpenRemoteBaseKey('LocalMachine',$computer)
+				$UninstallRef  = $HKLM.OpenSubKey($UninstallRegKey)
+				$Applications = $UninstallRef.GetSubKeyNames()
+			} catch {
+				Write-Verbose "Failed to read $UninstallRegKey"
+				Continue
+			}
+
+			foreach ($App in $Applications) {
+			$AppRegistryKey  = $UninstallRegKey + "\\" + $App
+			$AppDetails   = $HKLM.OpenSubKey($AppRegistryKey)
+			$AppGUID   = $App
+			$AppDisplayName  = $($AppDetails.GetValue("DisplayName"))
+			$AppVersion   = $($AppDetails.GetValue("DisplayVersion"))
+			$AppPublisher  = $($AppDetails.GetValue("Publisher"))
+			$AppInstalledDate = $($AppDetails.GetValue("InstallDate"))
+			$AppUninstall  = $($AppDetails.GetValue("UninstallString"))
+			if($UninstallRegKey -match "Wow6432Node") {
+				$Softwarearchitecture = "x86"
+			} else {
+				$Softwarearchitecture = "x64"
+			}
+			if(!$AppDisplayName) { continue }
+			$OutputObj = New-Object -TypeName PSobject 
+			$OutputObj | Add-Member -MemberType NoteProperty -Name ComputerName -Value $Computer.ToUpper()
+			$OutputObj | Add-Member -MemberType NoteProperty -Name AppName -Value $AppDisplayName
+			$OutputObj | Add-Member -MemberType NoteProperty -Name AppVersion -Value $AppVersion
+			$OutputObj | Add-Member -MemberType NoteProperty -Name AppVendor -Value $AppPublisher
+			$OutputObj | Add-Member -MemberType NoteProperty -Name InstalledDate -Value $AppInstalledDate
+			$OutputObj | Add-Member -MemberType NoteProperty -Name UninstallKey -Value $AppUninstall
+			$OutputObj | Add-Member -MemberType NoteProperty -Name AppGUID -Value $AppGUID
+			$OutputObj | Add-Member -MemberType NoteProperty -Name SoftwareArchitecture -Value $Softwarearchitecture
+			$OutputObj
+			}
+		}	
+	}
+ }
+}
+
+end {}

--- a/bootstrap/install_packages/InstallDependencies.ps1
+++ b/bootstrap/install_packages/InstallDependencies.ps1
@@ -1,0 +1,97 @@
+﻿########################################################
+# Install packages
+###################################################### 
+
+Set-ExecutionPolicy Unrestricted -Scope CurrentUser
+
+$InstallDir=$env:ProgramW6432
+$pathValue=$env:Path
+$IsChocoEnvPathPresent = Test-Path $env:ChocolateyInstall
+$IsVboxExtensionPackPresent=$InstallDir + "\Oracle\VirtualBox\ExtensionPacks\Oracle_VM_VirtualBox_Extension_Pack"
+   
+if(!( $IsChocoEnvPathPresent))
+    {
+    Write-Host "Installing Chocolatey"
+    powershell -NoProfile -ExecutionPolicy Unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" 
+    }
+    else
+    {
+
+     $chocVersion=choco --version
+
+     if(!($chocVersion -match "0.9.9.12"))
+     {
+     Write-Host "Updating chocolatey to latest version !"
+     choco upgrade chocolatey 
+
+     }
+      Write-Host "Chocolatey present  !"
+    }
+    
+ $env:PSModulePath = [System.Environment]::GetEnvironmentVariable("PSModulePath","Machine") #refresh env variables 
+
+
+Write-Host "Installing latest packages for ....virtual box and extension pack, vagrant and git"
+
+#######################_____VirtualBox____################################ 
+
+$Vbox=.\Get-InstalledSoftware.ps1 -ComputerName $env:COMPUTERNAME | ? {$_.AppName -match “VirtualBox” } -Verbose
+
+
+if(!($Vbox.AppVersion -ne $null -and $Vbox.AppVersion -match "5.0.20")  )
+    {
+     choco install virtualbox -version 5.0.20.106931 -y --force  
+    }
+    else
+    {
+     Write-Host("Virtual Box Version "+$Vbox.AppVersion +" present, skipping installation ! ")
+    } 
+       
+ if (!($IsVboxExtensionPackPresent )) 
+    {
+    Write-Host "Installing VirtualBox extensions"
+    choco install virtualbox.extensionpack -version 5.0.20.106931 -y 
+    }
+    else
+    { 
+    Write-Host "VirtualBox Extensions present, skipping installation !"
+    }
+   
+#########################_____Vagrant____################################# 
+   
+  $Vagrant=.\Get-InstalledSoftware.ps1 -ComputerName $env:COMPUTERNAME | ? {$_.AppName -match “vagrant” } -Verbose
+
+
+  if(!($Vagrant.AppVersion -ne $null -and $Vagrant.AppVersion -match "1.8.1") )
+    {
+     choco install vagrant -version 1.8.1 --force -y  
+    }
+    else
+    {
+    Write-Host("Virtual Box Version "+$Vagrant.AppVersion+ "  present, skipping installation ! ")
+    }
+       
+######################____Git____#################################### 
+
+   $gitVersion= .\Get-InstalledSoftware.ps1 -ComputerName $env:COMPUTERNAME | ? {$_.AppName -match “Git version” } -Verbose
+
+   if(!( $gitVersion.AppVersion -ne $null -and $gitVersion -match '2.8.2' ))
+    {
+    choco install git -version 2.8.2 -y --force
+    }
+    else
+    {
+    Write-Host("Git version present "+$gitVersion.AppVersion+" skipping installation ! ")
+    }
+
+   $env:PSModulePath = [System.Environment]::GetEnvironmentVariable("PSModulePath","Machine") #refresh env variables 
+ 
+######################################################
+# Running vagrant
+######################################################
+
+vagrant up
+
+echo("------------------------------------------------------")
+echo("Please run 'vagrant ssh' from Git Bash")
+echo("-------------------------------------------------------")


### PR DESCRIPTION
To test this script
1) open windows powershell console
2) navigate to the directory where scripts are placed
3) run the script by typing   .\InstallDependencies.ps1

This will be ideally run from a bootstrap folder where vagrant file is placed.
